### PR TITLE
Resolve scoped packages like @angular/core

### DIFF
--- a/src/plugins/universal-resolver.js
+++ b/src/plugins/universal-resolver.js
@@ -31,7 +31,7 @@ function repositoryUrlNotFoundResponse() {
 function doRequest(packageName, type, cb) {
   const config = registryConfig[type];
 
-  const url = util.format(config.registry, packageName);
+  const url = util.format(config.registry, packageName.replace(/\//g, '%2f'));
 
   got.get(url, function (err, data) {
     if (err) {

--- a/test/universal-resolver.spec.js
+++ b/test/universal-resolver.spec.js
@@ -62,6 +62,22 @@ describe('resolver', () => {
         done();
       });
     });
+
+    it('escapes slashes in package names', (done) => {
+      const options = {
+        method: 'GET',
+        url: '/q/npm/@angular/core'
+      };
+
+      this.gotStub.yields(null);
+
+      server.inject(options, (response) => {
+        assert.equal(this.gotStub.callCount, 1);
+        assert.equal(this.gotStub.args[0][0], 'https://registry.npmjs.org/@angular%2fcore');
+        assert.equal(this.gotStub.args[0][1].json, undefined);
+        done();
+      });
+    });
   });
 
   describe('response', () => {


### PR DESCRIPTION
For example, https://githublinker.herokuapp.com/q/npm/@angular/core
doesn't work, but it will with this patch.