### PR TITLE
Add pypi support

### DIFF
--- a/config.json
+++ b/config.json
@@ -39,5 +39,13 @@
       "/repositories/git",
       "/homepage"
     ]
+  },
+  "pypi": {
+    "registry": "https://pypi.python.org/pypi/%s/json",
+    "fallback": "https://pypi.python.org/pypi/%s",
+    "xpaths": [
+      "/info/home_page",
+      "/info/package_url"
+    ]
   }
 }


### PR DESCRIPTION
In favor of add Python support https://github.com/OctoLinker/browser-extension/issues/33 this addition is needed. 