### PR TITLE
Add support for Rust crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The supported registries are:
   - [getcomposer.org](https://getcomposer.org)
   - [rubygems.org](https://rubygems.org)
   - [pypi.python.org](https://pypi.python.org)
+  - [crates.io](https://crates.io)
   
 ## Find a package
 
@@ -19,6 +20,7 @@ Registry must be one of:
   - `composer`
   - `rubygems`
   - `pypi`
+  - `crates`
 
 Example:
 

--- a/config.json
+++ b/config.json
@@ -47,5 +47,13 @@
       "/info/home_page",
       "/info/package_url"
     ]
+  },
+  "crates": {
+    "registry": "https://crates.io/api/v1/crates/%s",
+    "fallback": "https://crates.io/crates/%s",
+    "xpaths": [
+      "/crate/repository",
+      "/crate/homepage"
+    ]
   }
 }


### PR DESCRIPTION
This is needed for https://github.com/OctoLinker/browser-extension/issues/45