### PR TITLE
Add support for GitHub URLs containing paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "boom": "^3.1.2",
-    "github-url-from-git": "^1.4.0",
+    "github-url-to-object": "^2.2.6",
     "got": "^6.3.0",
     "hapi": "^14.1.0",
     "is-url": "^1.2.1",

--- a/src/utils/repository-url.js
+++ b/src/utils/repository-url.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var githubUrl = require('github-url-from-git');
+var nodeUrl = require('url');
+var githubUrl = require('github-url-to-object');
 
 module.exports = function(url) {
   if (typeof url !== 'string') {
@@ -24,11 +25,11 @@ module.exports = function(url) {
   url = url.replace('https+git://', 'git+https://');
   url = url.replace('://www.github.com', '://github.com');
 
-  // Resolve detail link
-  var stripDetails = url.match(/https?:\/\/github.com(\/[^\/]+){2,2}/g);
-  if (stripDetails) {
-    url = stripDetails[0];
+  // Ensure there is a protocol (`github-url-to-object` needs it)
+  if (nodeUrl.parse(url).protocol === null) {
+    url = 'https://' + url;
   }
 
-  return githubUrl(url);
+  var githubInfo = githubUrl(url);
+  return githubInfo && githubInfo.https_url || url;
 };

--- a/test/functional.js
+++ b/test/functional.js
@@ -29,6 +29,7 @@ describe('functional', () => {
   testUrl('/q/composer/phpunit/phpunit', 'https://github.com/sebastianbergmann/phpunit');
   testUrl('/q/rubygems/nokogiri', 'https://github.com/sparklemotion/nokogiri');
   testUrl('/q/npm/request', 'https://github.com/request/request');
+  testUrl('/q/npm/babel-helper-regex', 'https://github.com/babel/babel/tree/master/packages/babel-helper-regex');
   testUrl('/q/pypi/simplejson', 'https://github.com/simplejson/simplejson');
   testUrl('/q/crates/libc', 'https://github.com/rust-lang/libc');
 });

--- a/test/repository-url.spec.js
+++ b/test/repository-url.spec.js
@@ -15,7 +15,6 @@ describe('repository url', function() {
     'https://www.github.com/john/doe/',
     'http://github.com/john/doe/tree/master',
     'https://github.com/john/doe/tree/master',
-    'https://github.com/john/doe/tree/master/foo',
     'john/doe',
     'john/doe/'
   ];
@@ -29,5 +28,10 @@ describe('repository url', function() {
     it('resolves ' + type, function() {
       assert.equal(findRepositoryUrl(node), 'https://github.com/john/doe');
     });
+  });
+
+  var detailUrl = 'https://github.com/john/doe/tree/master/foo';
+  it('resolves ' + detailUrl, function() {
+    assert.equal(findRepositoryUrl(detailUrl), 'https://github.com/john/doe/tree/master/foo');
   });
 });


### PR DESCRIPTION
This will make it so `babel-*` packages like `babel-helper-regex` will
correctly link to e.g.
https://github.com/babel/babel/tree/master/packages/babel-helper-regex
instead of https://github.com/babel/babel/. See the commit messages for
more details.