### PR TITLE
Add pre-existing jscs/jshint to test script

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -10,9 +10,5 @@
   "disallowMultipleLineBreaks": true,
   "disallowKeywordsOnNewLine": ["else"],
   "disallowTrailingWhitespace": true,
-  "requireLineFeedAtFileEnd": true,
-  "validateJSDoc": {
-    "checkParamNames": true,
-    "requireParamTypes": true
-  }
+  "requireLineFeedAtFileEnd": true
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "esversion": 6,
   "curly": true,
   "eqeqeq": true,
   "immed": true,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "node server.js",
     "jscs": "jscs $(git ls-files | grep js$)",
     "jshint": "jshint $(git ls-files | grep js$)",
+    "lint": "npm run jscs && npm run jshint",
+    "pretest": "npm run lint",
     "test": "mocha",
     "watch-test": "mocha -w"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
+    "jscs": "jscs $(git ls-files | grep js$)",
+    "jshint": "jshint $(git ls-files | grep js$)",
     "test": "mocha",
     "watch-test": "mocha -w"
   },
@@ -30,6 +32,8 @@
     "url": "https://github.com/octo-linker/live-resolver"
   },
   "devDependencies": {
+    "jscs": "^3.0.7",
+    "jshint": "^2.9.4",
     "lodash": "^4.6.1",
     "mocha": "^3.0.1",
     "sinon": "^1.16.1",

--- a/src/plugins/universal-resolver.js
+++ b/src/plugins/universal-resolver.js
@@ -6,7 +6,7 @@ const Joi = require('joi');
 const isUrl = require('is-url');
 const Boom = require('boom');
 const repositoryUrl = require('../utils/repository-url');
-const xpathHelper = require('../utils/xpath-helper')
+const xpathHelper = require('../utils/xpath-helper');
 const insight = require('../utils/insight.js');
 const registryConfig = require('../../config.json');
 
@@ -25,7 +25,7 @@ function parseFailedResponse() {
 function repositoryUrlNotFoundResponse() {
   return Boom.create(500, 'Repository url not found', {
     eventKey: 'repository_url_not_found'
-  })
+  });
 }
 
 function doRequest(packageName, type, cb) {
@@ -85,7 +85,7 @@ exports.register = (server, options, next) => {
               registry: type,
               package: pkg,
               referer: request.headers.referer
-            }
+            };
 
             doRequest(pkg, type, function(err, url) {
               if (err) {

--- a/src/utils/insight.js
+++ b/src/utils/insight.js
@@ -48,4 +48,4 @@ init();
 module.exports = {
   trackEvent,
   trackError,
-}
+};

--- a/src/utils/xpath-helper.js
+++ b/src/utils/xpath-helper.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const jpath = require('json-path')
+const jpath = require('json-path');
 
 function xpathResolver(json, selector) {
   try {

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const sinon = require('sinon');
-require('sinon-as-promised')
+require('sinon-as-promised');
 const got = require('got');
 const hapi = require('hapi');
 const plugin = require('../src/plugins/ping.js');
@@ -41,7 +41,7 @@ describe('ping', () => {
       url: '/ping?url=http://awesomefooland.com'
     };
 
-    server.inject(options, (response) => {
+    server.inject(options, () => {
       assert.equal(this.gotStub.callCount, 1);
       assert.equal(this.gotStub.args[0][0], 'http://awesomefooland.com');
       done();

--- a/test/universal-resolver.spec.js
+++ b/test/universal-resolver.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const sinon = require('sinon');
-require('sinon-as-promised')
+require('sinon-as-promised');
 const got = require('got');
 const cache = require('memory-cache');
 const hapi = require('hapi');
@@ -56,7 +56,7 @@ describe('resolver', () => {
     it('fetch package information from registry', (done) => {
       this.gotStub.resolves();
 
-      server.inject(options, (response) => {
+      server.inject(options, () => {
         assert.equal(this.gotStub.callCount, 1);
         assert.equal(this.gotStub.args[0][0], 'http://bower.herokuapp.com/packages/foo');
         done();
@@ -71,7 +71,7 @@ describe('resolver', () => {
 
       this.gotStub.resolves();
 
-      server.inject(options, (response) => {
+      server.inject(options, () => {
         assert.equal(this.gotStub.callCount, 1);
         assert.equal(this.gotStub.args[0][0], 'https://registry.npmjs.org/@angular%2fcore');
         done();

--- a/test/xpath-helper.spec.js
+++ b/test/xpath-helper.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const sinon = require('sinon');
-const jpath = require('json-path')
+const jpath = require('json-path');
 const xpathHelper = require('../src/utils/xpath-helper.js');
 
 describe('xpath-helper', () => {


### PR DESCRIPTION
While working on https://github.com/OctoLinker/live-resolver/pull/21, I
noticed that there's no programmatic enforcement of code style, so I
found the .jscsrc and .jshintrc files and made sure that they were being
checked as part of `npm test`. This required some small modifications to
both files, but I'm sure we can resolve those later, or even switch to
`eslint`, like in https://github.com/OctoLinker/browser-extension/