### PR TITLE
Make npm links fallback to npmjs.org if repo url 404s

### DIFF
--- a/src/plugins/universal-resolver.js
+++ b/src/plugins/universal-resolver.js
@@ -55,7 +55,12 @@ function doRequest(packageName, type, cb) {
       return cb(repositoryUrlNotFoundResponse());
     }
 
-    cb(null, url);
+    got.get(url).then(() => {
+      cb(null, url);
+    }).catch(() => {
+      url = util.format(config.fallback, packageName);
+      cb(null, url);
+    });
   }, (err) => {
     if (err.code === 404) {
       return cb(notFoundResponse());

--- a/test/functional.js
+++ b/test/functional.js
@@ -28,6 +28,7 @@ describe('functional', () => {
   testUrl('/q/rubygems/nokogiri', 'https://github.com/sparklemotion/nokogiri');
   testUrl('/q/npm/request', 'https://github.com/request/request');
   testUrl('/q/npm/babel-helper-regex', 'https://github.com/babel/babel/tree/master/packages/babel-helper-regex');
+  testUrl('/q/npm/audio-context-polyfill', 'https://npmjs.org/package/audio-context-polyfill');
   testUrl('/q/pypi/simplejson', 'https://github.com/simplejson/simplejson');
   testUrl('/q/crates/libc', 'https://github.com/rust-lang/libc');
 });


### PR DESCRIPTION
fixes https://github.com/OctoLinker/browser-extension/issues/287