### PR TITLE
npm: fallback to www.npmjs.com instead of npmjs.org

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,7 +24,7 @@
   },
   "npm": {
     "registry": "https://registry.npmjs.org/%s",
-    "fallback": "https://npmjs.org/package/%s",
+    "fallback": "https://www.npmjs.com/package/%s",
     "xpaths": [
       "/url",
       "/repository",

--- a/test/functional.js
+++ b/test/functional.js
@@ -28,7 +28,7 @@ describe('functional', () => {
   testUrl('/q/rubygems/nokogiri', 'https://github.com/sparklemotion/nokogiri');
   testUrl('/q/npm/request', 'https://github.com/request/request');
   testUrl('/q/npm/babel-helper-regex', 'https://github.com/babel/babel/tree/master/packages/babel-helper-regex');
-  testUrl('/q/npm/audio-context-polyfill', 'https://npmjs.org/package/audio-context-polyfill');
+  testUrl('/q/npm/audio-context-polyfill', 'https://www.npmjs.com/package/audio-context-polyfill');
   testUrl('/q/pypi/simplejson', 'https://github.com/simplejson/simplejson');
   testUrl('/q/crates/libc', 'https://github.com/rust-lang/libc');
 });


### PR DESCRIPTION
npmjs.org does a 301 redirect to www.npmjs.com, so just go directly there
instead. For example: https://npmjs.org/package/audio-context-polyfill