### PR TITLE
Fetch repo from custom go import path

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -153,6 +153,18 @@
         }
       }
     },
+    "cheerio": {
+      "version": "0.17.0",
+      "from": "cheerio@>=0.17.0 <0.18.0",
+      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.17.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        }
+      }
+    },
     "circular-json": {
       "version": "0.3.1",
       "from": "circular-json@>=0.3.1 <0.4.0",
@@ -252,6 +264,16 @@
       "resolved": "http://registry.npmjs.org/create-thenable/-/create-thenable-1.0.2.tgz",
       "dev": true
     },
+    "CSSselect": {
+      "version": "0.4.1",
+      "from": "CSSselect@>=0.4.0 <0.5.0",
+      "resolved": "http://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz"
+    },
+    "CSSwhat": {
+      "version": "0.4.7",
+      "from": "CSSwhat@>=0.4.0 <0.5.0",
+      "resolved": "http://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
+    },
     "d": {
       "version": "0.1.1",
       "from": "d@>=0.1.1 <0.2.0",
@@ -300,10 +322,42 @@
         }
       }
     },
+    "dom-serializer": {
+      "version": "0.0.1",
+      "from": "dom-serializer@>=0.0.0 <0.1.0",
+      "resolved": "http://registry.npmjs.org/dom-serializer/-/dom-serializer-0.0.1.tgz",
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "from": "domelementtype@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "from": "domelementtype@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+    },
+    "domhandler": {
+      "version": "2.2.1",
+      "from": "domhandler@>=2.2.0 <2.3.0",
+      "resolved": "http://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
+    },
+    "domutils": {
+      "version": "1.4.3",
+      "from": "domutils@>=1.4.0 <1.5.0",
+      "resolved": "http://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz"
+    },
     "duplexer3": {
       "version": "0.1.4",
       "from": "duplexer3@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz"
+    },
+    "entities": {
+      "version": "1.1.1",
+      "from": "entities@>=1.1.1 <1.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "es5-ext": {
       "version": "0.10.12",
@@ -475,6 +529,11 @@
       "from": "file-entry-cache@>=2.0.0 <3.0.0",
       "resolved": "http://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "dev": true
+    },
+    "find-reachable-urls": {
+      "version": "1.0.0",
+      "from": "find-reachable-urls@latest",
+      "resolved": "http://registry.npmjs.org/find-reachable-urls/-/find-reachable-urls-1.0.0.tgz"
     },
     "find-up": {
       "version": "1.1.2",
@@ -746,10 +805,44 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "dev": true
     },
+    "heads": {
+      "version": "1.2.0",
+      "from": "heads@>=1.2.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/heads/-/heads-1.2.0.tgz",
+      "dependencies": {
+        "async": {
+          "version": "2.1.5",
+          "from": "async@>=2.0.0-rc.6 <3.0.0",
+          "resolved": "http://registry.npmjs.org/async/-/async-2.1.5.tgz"
+        }
+      }
+    },
     "hoek": {
       "version": "4.1.0",
       "from": "hoek@4.x.x",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.0.tgz"
+    },
+    "htmlparser2": {
+      "version": "3.7.3",
+      "from": "htmlparser2@>=3.7.2 <3.8.0",
+      "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+      "dependencies": {
+        "domutils": {
+          "version": "1.5.1",
+          "from": "domutils@>=1.5.0 <1.6.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
+        },
+        "entities": {
+          "version": "1.0.0",
+          "from": "entities@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        }
+      }
     },
     "ignore": {
       "version": "3.2.2",
@@ -925,6 +1018,11 @@
       "from": "keen.io@0.1.3",
       "resolved": "http://registry.npmjs.org/keen.io/-/keen.io-0.1.3.tgz"
     },
+    "lets-get-meta": {
+      "version": "2.0.1",
+      "from": "lets-get-meta@latest",
+      "resolved": "http://registry.npmjs.org/lets-get-meta/-/lets-get-meta-2.0.1.tgz"
+    },
     "levn": {
       "version": "0.3.0",
       "from": "levn@>=0.3.0 <0.4.0",
@@ -934,8 +1032,7 @@
     "lodash": {
       "version": "4.17.4",
       "from": "lodash@4.17.4",
-      "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "dev": true
+      "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -1279,8 +1376,7 @@
     "pify": {
       "version": "2.3.0",
       "from": "pify@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "boom": "4.2.0",
+    "find-reachable-urls": "1.0.0",
     "github-url-to-object": "3.0.0",
     "got": "6.7.1",
     "hapi": "16.1.0",
@@ -24,6 +25,7 @@
     "joi": "10.2.1",
     "json-path": "0.1.3",
     "keen.io": "0.1.3",
+    "lets-get-meta": "2.0.1",
     "memory-cache": "0.1.6",
     "newrelic": "1.36.2"
   },

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ if (process.env.NEW_RELIC_LICENSE_KEY) {
 }
 
 const hapi = require('hapi');
+const goResolverPlugin = require('./src/plugins/go-resolver.js');
 const resolverPlugin = require('./src/plugins/universal-resolver.js');
 const pingPlugin = require('./src/plugins/ping.js');
 const homePlugin = require('./src/plugins/home.js');
@@ -14,6 +15,7 @@ server.connection({
 
 server.register([
   resolverPlugin,
+  goResolverPlugin,
   pingPlugin,
   homePlugin,
 ], (err) => {

--- a/src/plugins/go-resolver.js
+++ b/src/plugins/go-resolver.js
@@ -1,0 +1,91 @@
+const Joi = require('joi');
+const findReachableUrls = require('find-reachable-urls');
+const readMeta = require('lets-get-meta');
+const got = require('got');
+const insight = require('../utils/insight');
+
+const getGoMeta = async url => got.get(url)
+  .then((response) => {
+    const meta = readMeta(response.body);
+
+    if (!meta['go-source']) {
+      throw new Error('go-source meta is missing');
+    }
+
+    const values = meta['go-source'].replace(/\s+/, ' ').split(' ');
+
+    return {
+      projectRoot: values[0],
+      projectUrl: values[1],
+      dirTemplate: values[2].replace('{/dir}', ''),
+    };
+  });
+
+const resolveUrl = async (url) => {
+  let goMetaConfig;
+
+  try {
+    // Preferred with https
+    goMetaConfig = await getGoMeta(`https://${url}?go-get=1`);
+  } catch (err) {
+    // Fallback insecure
+    goMetaConfig = await getGoMeta(`http://${url}?go-get=1`);
+  }
+
+  const urls = await findReachableUrls([
+    url.replace(goMetaConfig.projectRoot, goMetaConfig.dirTemplate),
+    goMetaConfig.projectUrl,
+  ]);
+
+  if (!urls[0]) {
+    throw new Error('No url is reachable');
+  }
+
+  return urls[0];
+};
+
+exports.register = (server, options, next) => {
+  server.route([{
+    path: '/q/go/{package*}',
+    method: 'GET',
+    config: {
+      validate: {
+        params: {
+          package: Joi.required(),
+        },
+      },
+      handler: async (request, reply) => {
+        const pkg = request.params.package;
+
+        const eventData = {
+          registry: 'go',
+          package: pkg,
+          referer: request.headers.referer,
+        };
+
+        try {
+          const url = await resolveUrl(pkg);
+          reply({
+            url,
+          });
+
+          eventData.url = url;
+          insight.trackEvent('resolved', eventData, request);
+        } catch (err) {
+          const eventKey = (err.data || {}).eventKey;
+          insight.trackError(eventKey, err, eventData, request);
+          reply(err);
+        }
+      },
+    },
+  }]);
+
+  next();
+};
+
+exports.register.attributes = {
+  pkg: {
+    name: 'Go Resolver',
+    version: '1.0.0',
+  },
+};

--- a/test/functional.js
+++ b/test/functional.js
@@ -31,4 +31,5 @@ describe('functional', () => {
   testUrl('/q/npm/audio-context-polyfill', 'https://www.npmjs.com/package/audio-context-polyfill');
   testUrl('/q/pypi/simplejson', 'https://github.com/simplejson/simplejson');
   testUrl('/q/crates/libc', 'https://github.com/rust-lang/libc');
+  testUrl('/q/go/k8s.io/kubernetes/pkg/api', 'https://github.com/kubernetes/kubernetes/tree/master/pkg/api');
 });


### PR DESCRIPTION
The key to get custom import working is in the <meta> tag named `go-import`. When requesting https://k8s.io/kubernetes/pkg/api we know that `k8s.io/kubernetes/pkg/api` points to https://github.com/kubernetes/kubernetes/tree/master/pkg/api.

[http://localhost:3000/q/go/k8s.io/kubernetes/pkg/api](http://localhost:3000/q/go/k8s.io/kubernetes/pkg/api)
[http://localhost:3000/q/go/code.gitea.io/gitea/modules/setting](http://localhost:3000/q/go/code.gitea.io/gitea/modules/setting)


https://github.com/OctoLinker/browser-extension/issues/264