### PR TITLE
Use async/await in tests

### DIFF
--- a/test/functional.js
+++ b/test/functional.js
@@ -14,12 +14,10 @@ describe('functional', () => {
   });
 
   function testUrl(path, expectedUrl) {
-    it(`resolves ${path} to ${expectedUrl}`, (done) => {
-      got(server.info.uri + path).then((response) => {
-        const url = JSON.parse(response.body).url;
-        assert.deepStrictEqual(url, expectedUrl);
-        done();
-      });
+    it(`resolves ${path} to ${expectedUrl}`, async () => {
+      const response = await got(server.info.uri + path);
+      const url = JSON.parse(response.body).url;
+      assert.deepStrictEqual(url, expectedUrl);
     });
   }
 


### PR DESCRIPTION
Note that mocha allows test functions to return a promise instead of
calling a `done` callback. Since the `async` keyword causes a promise to
be returned, we don't need to call `done` (in fact, it is an error to).

https://mochajs.org/#working-with-promises

EDIT: best reviewed ignoring whitespace: https://github.com/OctoLinker/live-resolver/pull/31/files?&w=true