### PR TITLE
package.json: Specify Node ^7.6.0 as engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Stefan Buck",
   "license": "MIT",
   "engines": {
-    "node": "7.6.0"
+    "node": "^7.6.0"
   },
   "dependencies": {
     "boom": "4.2.0",


### PR DESCRIPTION
This allows newer Node versions to be used.