### PR TITLE
Travis: test on latest Node v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- v7.6.0
+- v7
 deploy:
   provider: heroku
   app: githublinker


### PR DESCRIPTION
c410ff4 (#38) caused the heroku [deploy] to use Node v7.7.4 instead of
v7.6.0, so let's make sure to test on the latest Node as well.

[deploy]: https://travis-ci.org/OctoLinker/live-resolver/builds/215311723#L386-L387