### PR TITLE
Bump find-reachable-urls to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "boom": "4.2.0",
-    "find-reachable-urls": "1.0.0",
+    "find-reachable-urls": "^1.1.1",
     "github-url-to-object": "3.0.0",
     "got": "6.7.1",
     "hapi": "16.1.0",

--- a/src/plugins/go-resolver.js
+++ b/src/plugins/go-resolver.js
@@ -32,16 +32,16 @@ const resolveUrl = async (url) => {
     goMetaConfig = await getGoMeta(`http://${url}?go-get=1`);
   }
 
-  const urls = await findReachableUrls([
+  const reachableUrl = await findReachableUrls([
     url.replace(goMetaConfig.projectRoot, goMetaConfig.dirTemplate),
     goMetaConfig.projectUrl,
-  ]);
+  ], { firstMatch: true });
 
-  if (!urls[0]) {
+  if (!reachableUrl) {
     throw new Error('No url is reachable');
   }
 
-  return urls[0];
+  return reachableUrl;
 };
 
 exports.register = (server, options, next) => {

--- a/src/utils/do-request.js
+++ b/src/utils/do-request.js
@@ -51,13 +51,13 @@ module.exports = async function doRequest(packageName, type) {
 
     const fallbackUrl = util.format(config.fallback, packageName);
     const tryUrls = validUrls.concat(fallbackUrl);
-    const reachableUrls = await findReachableUrls(tryUrls);
+    const reachableUrl = await findReachableUrls(tryUrls, { firstMatch: true });
 
-    if (reachableUrls.length === 0) {
+    if (!reachableUrl) {
       throw notFoundResponse();
     }
 
-    return reachableUrls[0];
+    return reachableUrl;
   } catch (err) {
     if (err.code === 404) {
       throw notFoundResponse();

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,6 +83,12 @@ async@^2.0.0-rc.6:
   dependencies:
     lodash "^4.14.0"
 
+async@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.3.0.tgz#1013d1051047dd320fe24e494d5c66ecaf6147d9"
+  dependencies:
+    lodash "^4.14.0"
+
 async@~0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
@@ -598,10 +604,11 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-find-reachable-urls@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/find-reachable-urls/-/find-reachable-urls-1.0.0.tgz#02af2622ea6d6347908f017cd8832a7d4df7ecbc"
+find-reachable-urls@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/find-reachable-urls/-/find-reachable-urls-1.1.1.tgz#e1592262a2169585f681a3f590856b1462eda239"
   dependencies:
+    async "^2.3.0"
     heads "^1.2.0"
     pify "^2.3.0"
 


### PR DESCRIPTION
In the previous version of [`find-reachable-urls`](https://github.com/stefanbuck/find-reachable-urls) the callback was invoked after all urls have been checked. Sometimes it takes very long to complete all requests. With version`1.1.1` you can claim your interest in the first reachable url which will stop any further requests. 