### PR TITLE
remove functional test for buble

### DIFF
--- a/test/functional.js
+++ b/test/functional.js
@@ -29,7 +29,6 @@ parallel('functional', () => {
   testUrl('/q/npm/babel-helper-regex', 'https://github.com/babel/babel/tree/master/packages/babel-helper-regex');
   testUrl('/q/npm/audio-context-polyfill', 'https://www.npmjs.com/package/audio-context-polyfill');
   testUrl('/q/npm/github-url-from-username-repo', 'https://github.com/robertkowalski/github-url-from-username-repo');
-  testUrl('/q/npm/buble', 'https://gitlab.com/Rich-Harris/buble#README');
   testUrl('/q/pypi/simplejson', 'https://github.com/simplejson/simplejson');
   testUrl('/q/crates/libc', 'https://github.com/rust-lang/libc');
   testUrl('/q/go/k8s.io/kubernetes/pkg/api', 'https://github.com/kubernetes/kubernetes/tree/master/pkg/api');


### PR DESCRIPTION
The package buble moved to github which let the functional tests fail.
Also I think there is no value for testing projects hosted on different hosting
sites. Live resolver reads the url from the package.json regardless what the value is