### PR TITLE
Changes required to use Hapi 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "node": "8.9.x"
   },
   "dependencies": {
-    "boom": "^6.0.0",
+    "boom": "^7.1.1",
     "find-reachable-urls": "^1.1.1",
     "github-url-to-object": "^4.0.2",
     "got": "^7.1.0",
-    "hapi": "^16.6.2",
+    "hapi": "^17.2.0",
     "is-url": "^1.2.2",
-    "joi": "^11.1.1",
+    "joi": "^13.0.2",
     "json-path": "^0.1.3",
     "keen.io": "^0.1.3",
     "lets-get-meta": "^2.1.1",

--- a/server.js
+++ b/server.js
@@ -10,26 +10,28 @@ const javaPlugin = require('./src/plugins/java-resolver.js');
 const pingPlugin = require('./src/plugins/ping.js');
 const homePlugin = require('./src/plugins/home.js');
 
-const server = new hapi.Server();
-server.connection({
+const server = new hapi.Server({
   port: process.env.PORT || 3000,
 });
 
-server.register([
-  resolverPlugin,
-  javaPlugin,
-  goResolverPlugin,
-  melpaResolverPlugin,
-  pingPlugin,
-  homePlugin,
-], (err) => {
-  if (err) {
-    return console.error('Failed to register server:', err);
-  }
+const init = async () => {
+  await server.register([
+    resolverPlugin,
+    javaPlugin,
+    goResolverPlugin,
+    melpaResolverPlugin,
+    pingPlugin,
+    homePlugin,
+  ]);
 
-  server.start(() => {
-    console.log('Server running at:', server.info.uri);
-  });
+  await server.start();
+
+  console.log(`Server running at: ${server.info.uri}`);
+};
+
+init().catch((err) => {
+  console.log(err);
+  process.exit(1);
 });
 
 module.exports = server;

--- a/src/plugins/home.js
+++ b/src/plugins/home.js
@@ -1,12 +1,12 @@
 const pkg = require('../../package.json');
 const insight = require('../utils/insight.js');
 
-exports.register = (server, options, next) => {
+const register = (server) => {
   server.route([{
     path: '/',
     method: 'GET',
     config: {
-      handler: (request, reply) => {
+      handler: (request) => {
         const repoUrl = pkg.repository.url;
         const short = repoUrl.replace('https://github.com/', '');
         const versionInfo = `<a href="${repoUrl}">${short}@${pkg.version}</a>`;
@@ -15,17 +15,14 @@ exports.register = (server, options, next) => {
           version: pkg.version,
         }, request);
 
-        reply(versionInfo);
+        return versionInfo;
       },
     },
   }]);
-
-  next();
 };
 
-exports.register.attributes = {
-  pkg: {
-    name: 'Home',
-    version: '1.0.0',
-  },
+exports.plugin = {
+  name: 'Home',
+  version: '1.0.0',
+  register,
 };

--- a/src/plugins/ping.js
+++ b/src/plugins/ping.js
@@ -1,8 +1,10 @@
 const got = require('got');
+const Boom = require('boom');
+
 const Joi = require('joi');
 const insight = require('../utils/insight.js');
 
-exports.register = (server, options, next) => {
+const register = (server) => {
   server.route([{
     path: '/ping',
     method: 'GET',
@@ -12,7 +14,7 @@ exports.register = (server, options, next) => {
           url: Joi.required(),
         },
       },
-      handler: async (request, reply) => {
+      handler: async (request) => {
         const url = request.query.url;
 
         try {
@@ -21,26 +23,23 @@ exports.register = (server, options, next) => {
             url,
           }, request);
 
-          reply({
+          return {
             url,
-          }).code(200);
-        } catch (err) {
-          insight.trackError('ping_error', err, {
-            url,
-          }, request);
+          };
+        } catch (error) {
+          const err = Boom.notFound('URL not found');
 
-          reply().code(404);
+          insight.trackError('ping_error', err, { url }, request);
+
+          return err;
         }
       },
     },
   }]);
-
-  next();
 };
 
-exports.register.attributes = {
-  pkg: {
-    name: 'Ping',
-    version: '1.0.0',
-  },
+exports.plugin = {
+  name: 'Ping',
+  version: '1.0.0',
+  register,
 };

--- a/src/plugins/universal-resolver.js
+++ b/src/plugins/universal-resolver.js
@@ -3,7 +3,7 @@ const insight = require('../utils/insight.js');
 const registryConfig = require('../../config.json');
 const doRequest = require('../utils/do-request.js');
 
-exports.register = (server, options, next) => {
+const register = (server) => {
   server.route([{
     path: '/q/{registry}/{package*}',
     method: 'GET',
@@ -14,7 +14,7 @@ exports.register = (server, options, next) => {
           package: Joi.required(),
         },
       },
-      handler: async (request, reply) => {
+      handler: async (request) => {
         const pkg = request.params.package;
         const type = request.params.registry;
         const eventData = {
@@ -28,24 +28,22 @@ exports.register = (server, options, next) => {
           eventData.url = url;
           insight.trackEvent('resolved', eventData, request);
 
-          reply({
+          return {
             url,
-          });
+          };
         } catch (err) {
           const eventKey = (err.data || {}).eventKey;
           insight.trackError(eventKey, err, eventData, request);
-          reply(err);
+
+          return err;
         }
       },
     },
   }]);
-
-  next();
 };
 
-exports.register.attributes = {
-  pkg: {
-    name: 'Universal Resolver',
-    version: '1.0.0',
-  },
+exports.plugin = {
+  name: 'Universal Resolver',
+  version: '1.0.0',
+  register,
 };

--- a/src/utils/do-request.js
+++ b/src/utils/do-request.js
@@ -68,10 +68,10 @@ module.exports = async function doRequest(packageName, type) {
 
     return reachableUrl;
   } catch (err) {
-    if (err.code === 404) {
+    if (err.statusCode === 404) {
       throw notFoundResponse();
     }
 
-    throw Boom.wrap(err);
+    throw Boom.boomify(err);
   }
 };

--- a/test/functional.js
+++ b/test/functional.js
@@ -7,12 +7,10 @@ parallel('functional', () => {
 
   before((done) => {
     server = require('../server'); // eslint-disable-line global-require
-    server.once('start', done);
+    server.events.once('start', done);
   });
 
-  after((done) => {
-    server.stop(done);
-  });
+  after(() => server.stop());
 
   function testUrl(path, expectedUrl) {
     it(`resolves ${path} to ${expectedUrl}`, async () => {

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -10,20 +10,14 @@ const plugin = require('../src/plugins/ping.js');
 describe('ping', () => {
   let server;
 
-  before((done) => {
+  before(async () => {
     server = new hapi.Server();
-    server.connection();
 
-    server.register(plugin, () => {
-      server.start(() => {
-        done();
-      });
-    });
+    await server.register(plugin);
+    return server.start();
   });
 
-  after((done) => {
-    server.stop(() => done());
-  });
+  after(() => server.stop());
 
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create();
@@ -34,21 +28,19 @@ describe('ping', () => {
     this.sandbox.restore();
   });
 
-  it('performs an HTTP HEAD request', (done) => {
+  it('performs an HTTP HEAD request', async () => {
     this.gotStub.resolves();
 
     const options = {
       url: '/ping?url=http://awesomefooland.com',
     };
 
-    server.inject(options, () => {
-      assert.equal(this.gotStub.callCount, 1);
-      assert.equal(this.gotStub.args[0][0], 'http://awesomefooland.com');
-      done();
-    });
+    await server.inject(options);
+    assert.equal(this.gotStub.callCount, 1);
+    assert.equal(this.gotStub.args[0][0], 'http://awesomefooland.com');
   });
 
-  it('returns 404 response if package can not be found', (done) => {
+  it('returns 404 response if package can not be found', async () => {
     const err = new Error('Some error');
     err.code = 404;
     this.gotStub.rejects(err);
@@ -58,13 +50,11 @@ describe('ping', () => {
       url: '/ping?url=http://awesomefooland.com',
     };
 
-    server.inject(options, (response) => {
-      assert.equal(response.statusCode, 404);
-      done();
-    });
+    const response = await server.inject(options);
+    assert.equal(response.statusCode, 404);
   });
 
-  it('returns project url', (done) => {
+  it('returns project url', async () => {
     this.gotStub.resolves();
 
     const options = {
@@ -72,9 +62,7 @@ describe('ping', () => {
       url: '/ping?url=http://awesomefooland.com',
     };
 
-    server.inject(options, (response) => {
-      assert.equal(response.statusCode, 200);
-      done();
-    });
+    const response = await server.inject(options);
+    assert.equal(response.statusCode, 200);
   });
 });

--- a/test/universal-resolver.spec.js
+++ b/test/universal-resolver.spec.js
@@ -4,7 +4,7 @@ require('sinon-as-promised');
 const got = require('got');
 const cache = require('memory-cache');
 const hapi = require('hapi');
-const resolverPlugin = require('../src/plugins/universal-resolver.js');
+const plugin = require('../src/plugins/universal-resolver.js');
 
 describe('resolver', () => {
   let server;
@@ -13,20 +13,14 @@ describe('resolver', () => {
     url: '/q/bower/foo',
   };
 
-  before((done) => {
+  before(async () => {
     server = new hapi.Server();
-    server.connection();
 
-    server.register(resolverPlugin, () => {
-      server.start(() => {
-        done();
-      });
-    });
+    await server.register(plugin);
+    return server.start();
   });
 
-  after((done) => {
-    server.stop(() => done());
-  });
+  after(() => server.stop());
 
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create();
@@ -40,28 +34,24 @@ describe('resolver', () => {
   });
 
   describe('fetch', () => {
-    it('returns an error if registry fetch fails', (done) => {
+    it('returns an error if registry fetch fails', async () => {
       const err = new Error('Some error');
       this.gotStub.rejects(err);
 
-      server.inject(options, (response) => {
-        assert.equal(response.statusCode, 500);
-        assert.equal(response.result.error, 'Internal Server Error');
-        done();
-      });
+      const response = await server.inject(options);
+      assert.equal(response.statusCode, 500);
+      assert.equal(response.result.error, 'Internal Server Error');
     });
 
-    it('fetch package information from registry', (done) => {
+    it('fetch package information from registry', async () => {
       this.gotStub.resolves();
 
-      server.inject(options, () => {
-        assert.equal(this.gotStub.callCount, 1);
-        assert.equal(this.gotStub.args[0][0], 'https://registry.bower.io/packages/foo');
-        done();
-      });
+      await server.inject(options);
+      assert.equal(this.gotStub.callCount, 1);
+      assert.equal(this.gotStub.args[0][0], 'https://registry.bower.io/packages/foo');
     });
 
-    it('escapes slashes in package names', (done) => {
+    it('escapes slashes in package names', async () => {
       const optionsScopePackage = {
         method: 'GET',
         url: '/q/npm/@angular/core',
@@ -69,42 +59,36 @@ describe('resolver', () => {
 
       this.gotStub.resolves();
 
-      server.inject(optionsScopePackage, () => {
-        assert.equal(this.gotStub.callCount, 1);
-        assert.equal(this.gotStub.args[0][0], 'https://registry.npmjs.org/@angular%2fcore');
-        done();
-      });
+      await server.inject(optionsScopePackage);
+      assert.equal(this.gotStub.callCount, 1);
+      assert.equal(this.gotStub.args[0][0], 'https://registry.npmjs.org/@angular%2fcore');
     });
   });
 
   describe('response', () => {
     describe('with 404', () => {
-      it('when package can not be found', (done) => {
+      it('when package can not be found', async () => {
         const err = new Error('Some error');
-        err.code = 404;
+        err.statusCode = 404;
         this.gotStub.rejects(err);
 
-        server.inject(options, (response) => {
-          assert.equal(response.statusCode, 404);
-          assert.equal(response.result.message, 'Package not found');
-          done();
-        });
+        const response = await server.inject(options);
+        assert.equal(response.statusCode, 404);
+        assert.equal(response.result.message, 'Package not found');
       });
     });
 
     describe('with 200', () => {
-      it('when no repository url is found', (done) => {
+      it('when no repository url is found', async () => {
         this.gotStub.resolves({
           body: JSON.stringify({
             url: '',
           }),
         });
 
-        server.inject(options, (response) => {
-          assert.equal(response.statusCode, 200);
-          assert.equal(response.result.url, 'https://bower.io/search/?q=foo');
-          done();
-        });
+        const response = await server.inject(options);
+        assert.equal(response.statusCode, 200);
+        assert.equal(response.result.url, 'https://bower.io/search/?q=foo');
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,12 +16,12 @@ abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
 
-accept@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/accept/-/accept-2.1.4.tgz#887af54ceee5c7f4430461971ec400c61d09acbb"
+accept@3.x.x:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/accept/-/accept-3.0.2.tgz#83e41cec7e1149f3fd474880423873db6c6cc9ac"
   dependencies:
-    boom "5.x.x"
-    hoek "4.x.x"
+    boom "7.x.x"
+    hoek "5.x.x"
 
 acorn-globals@^4.0.0:
   version "4.1.0"
@@ -67,12 +67,12 @@ ajv@^5.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ammo@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/ammo/-/ammo-2.0.4.tgz#bf80aab211698ea78f63ef5e7f113dd5d9e8917f"
+ammo@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ammo/-/ammo-3.0.0.tgz#30f322f70a0904eaee1788f4d26c5be1d72da181"
   dependencies:
-    boom "5.x.x"
-    hoek "4.x.x"
+    boom "6.x.x"
+    hoek "5.x.x"
 
 ansi-escapes@^1.1.0:
   version "1.4.0"
@@ -144,9 +144,9 @@ aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-b64@3.x.x:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/b64/-/b64-3.0.3.tgz#36afeee0d9345f046387ce6de8a6702afe5bb56e"
+b64@4.x.x:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/b64/-/b64-4.0.0.tgz#c37f587f0a383c7019e821120e8c3f58f0d22772"
 
 babel-code-frame@^6.16.0:
   version "6.26.0"
@@ -166,6 +166,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-time@2.x.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/big-time/-/big-time-2.0.0.tgz#70193b60faff72c96ed52331b555490e604d7ccc"
+
 bluebird@^2.9.34:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
@@ -180,16 +184,29 @@ boom@4.x.x:
   dependencies:
     hoek "4.x.x"
 
-boom@5.x.x, boom@^5.2.0:
+boom@5.x.x:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
   dependencies:
     hoek "4.x.x"
 
-boom@^6.0.0:
+boom@6.x.x:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/boom/-/boom-6.0.0.tgz#9b36c52a12afab3f0e55536131b7fd5021aad0cc"
   dependencies:
+    hoek "5.x.x"
+
+boom@7.x.x, boom@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-7.1.1.tgz#50392a4e3417e971f1ad28622c20e832275260bb"
+  dependencies:
+    hoek "5.x.x"
+
+bounce@1.x.x:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/bounce/-/bounce-1.2.0.tgz#e3bac68c73fd256e38096551efc09f504873c8c8"
+  dependencies:
+    boom "7.x.x"
     hoek "5.x.x"
 
 brace-expansion@^1.1.7:
@@ -211,12 +228,12 @@ builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-call@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/call/-/call-4.0.2.tgz#df76f5f51ee8dd48b856ac8400f7e69e6d7399c4"
+call@5.x.x:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/call/-/call-5.0.1.tgz#ac1b5c106d9edc2a17af2a4a4f74dd4f0c06e910"
   dependencies:
-    boom "5.x.x"
-    hoek "4.x.x"
+    boom "7.x.x"
+    hoek "5.x.x"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -236,19 +253,22 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-catbox-memory@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/catbox-memory/-/catbox-memory-2.0.4.tgz#433e255902caf54233d1286429c8f4df14e822d5"
+catbox-memory@3.x.x:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/catbox-memory/-/catbox-memory-3.1.1.tgz#4f398835a3d8f5992c31ddee24378467498a9c9a"
   dependencies:
-    hoek "4.x.x"
+    big-time "2.x.x"
+    boom "7.x.x"
+    hoek "5.x.x"
 
-catbox@^7.1.5:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/catbox/-/catbox-7.1.5.tgz#c56f7e8e9555d27c0dc038a96ef73e57d186bb1f"
+catbox@10.x.x:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/catbox/-/catbox-10.0.2.tgz#e6ac1f35102d1a9bd07915b82e508d12b50a8bfa"
   dependencies:
-    boom "5.x.x"
-    hoek "4.x.x"
-    joi "10.x.x"
+    boom "7.x.x"
+    bounce "1.x.x"
+    hoek "5.x.x"
+    joi "13.x.x"
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -345,11 +365,11 @@ content-type-parser@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
 
-content@3.x.x:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/content/-/content-3.0.6.tgz#9c2e301e9ae515ed65a4b877d78aa5659bb1b809"
+content@4.x.x:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/content/-/content-4.0.3.tgz#2224e0449e4258617bc5f7fb4dc2f17f321d21fc"
   dependencies:
-    boom "5.x.x"
+    boom "7.x.x"
 
 cookiejar@2.0.1:
   version "2.0.1"
@@ -372,11 +392,17 @@ create-thenable@~1.0.0:
     object.omit "~2.0.0"
     unique-concat "~0.2.2"
 
-cryptiles@3.x.x, cryptiles@^3.1.2:
+cryptiles@3.x.x:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
   dependencies:
     boom "5.x.x"
+
+cryptiles@4.x.x:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-4.1.1.tgz#169256b9df9fe3c73f8085c99e30b32247d4ab46"
+  dependencies:
+    boom "7.x.x"
 
 css-select@~1.2.0:
   version "1.2.0"
@@ -963,28 +989,27 @@ growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
-hapi@^16.6.2:
-  version "16.6.2"
-  resolved "https://registry.yarnpkg.com/hapi/-/hapi-16.6.2.tgz#690554fc9c5ca7ad2f8030bbfe21d5e5886cdc14"
+hapi@^17.2.0:
+  version "17.2.0"
+  resolved "https://registry.yarnpkg.com/hapi/-/hapi-17.2.0.tgz#e5d74b65235b443225e05d7b7510cdb80d4887e7"
   dependencies:
-    accept "^2.1.4"
-    ammo "^2.0.4"
-    boom "^5.2.0"
-    call "^4.0.2"
-    catbox "^7.1.5"
-    catbox-memory "^2.0.4"
-    cryptiles "^3.1.2"
-    heavy "^4.0.4"
-    hoek "^4.2.0"
-    iron "^4.0.5"
-    items "^2.1.1"
-    joi "^11.1.0"
-    mimos "^3.0.3"
-    podium "^1.3.0"
-    shot "^3.4.2"
-    statehood "^5.0.3"
-    subtext "^5.0.0"
-    topo "^2.0.2"
+    accept "3.x.x"
+    ammo "3.x.x"
+    boom "7.x.x"
+    bounce "1.x.x"
+    call "5.x.x"
+    catbox "10.x.x"
+    catbox-memory "3.x.x"
+    heavy "6.x.x"
+    hoek "5.x.x"
+    joi "13.x.x"
+    mimos "4.x.x"
+    podium "3.x.x"
+    shot "4.x.x"
+    statehood "6.x.x"
+    subtext "6.x.x"
+    teamwork "3.x.x"
+    topo "3.x.x"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -1040,15 +1065,15 @@ heads@^1.2.0:
     got "^6.3.0"
     pify "^2.3.0"
 
-heavy@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/heavy/-/heavy-4.0.4.tgz#36c91336c00ccfe852caa4d153086335cd2f00e9"
+heavy@6.x.x:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/heavy/-/heavy-6.1.0.tgz#1bbfa43dc61dd4b543ede3ff87db8306b7967274"
   dependencies:
-    boom "5.x.x"
-    hoek "4.x.x"
-    joi "10.x.x"
+    boom "7.x.x"
+    hoek "5.x.x"
+    joi "13.x.x"
 
-hoek@4.x.x, hoek@^4.2.0:
+hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
@@ -1138,13 +1163,13 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
-iron@4.x.x, iron@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/iron/-/iron-4.0.5.tgz#4f042cceb8b9738f346b59aa734c83a89bc31428"
+iron@5.x.x:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/iron/-/iron-5.0.4.tgz#003ed822f656f07c2b62762815f5de3947326867"
   dependencies:
-    boom "5.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
+    boom "7.x.x"
+    cryptiles "4.x.x"
+    hoek "5.x.x"
 
 is-extendable@^0.1.1:
   version "0.1.1"
@@ -1231,10 +1256,6 @@ isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isemail@2.x.x:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
-
 isemail@3.x.x:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.0.0.tgz#c89a46bb7a3361e1759f8028f9082488ecce3dff"
@@ -1252,26 +1273,13 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-items@2.x.x, items@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/items/-/items-2.1.1.tgz#8bd16d9c83b19529de5aea321acaada78364a198"
-
-joi@10.x.x:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-10.6.0.tgz#52587f02d52b8b75cdb0c74f0b164a191a0e1fc2"
+joi@13.x.x, joi@^13.0.2:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-13.0.2.tgz#8cc57a573b7c0b64108fa6fd85061c20fcb0d6b0"
   dependencies:
-    hoek "4.x.x"
-    isemail "2.x.x"
-    items "2.x.x"
-    topo "2.x.x"
-
-joi@^11.1.0, joi@^11.1.1:
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-11.4.0.tgz#f674897537b625e9ac3d0b7e1604c828ad913ccb"
-  dependencies:
-    hoek "4.x.x"
+    hoek "5.x.x"
     isemail "3.x.x"
-    topo "2.x.x"
+    topo "3.x.x"
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -1536,11 +1544,11 @@ mimic-response@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
-mimos@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/mimos/-/mimos-3.0.3.tgz#b9109072ad378c2b72f6a0101c43ddfb2b36641f"
+mimos@4.x.x:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimos/-/mimos-4.0.0.tgz#76e3d27128431cb6482fd15b20475719ad626a5a"
   dependencies:
-    hoek "4.x.x"
+    hoek "5.x.x"
     mime-db "1.x.x"
 
 minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
@@ -1619,12 +1627,12 @@ newrelic@^2.2.2:
   optionalDependencies:
     "@newrelic/native-metrics" "^2.1.0"
 
-nigel@2.x.x:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/nigel/-/nigel-2.0.2.tgz#93a1866fb0c52d87390aa75e2b161f4b5c75e5b1"
+nigel@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/nigel/-/nigel-3.0.0.tgz#a6e3378a8a34281e75ba1641e886a415d4be93ad"
   dependencies:
-    hoek "4.x.x"
-    vise "2.x.x"
+    hoek "5.x.x"
+    vise "3.x.x"
 
 nth-check@~1.0.1:
   version "1.0.1"
@@ -1722,15 +1730,15 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-pez@2.x.x:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/pez/-/pez-2.1.5.tgz#5ec2cc62500cc3eb4236d4a414cf5a17b5eb5007"
+pez@4.x.x:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pez/-/pez-4.0.1.tgz#d698ecf9a146c9188d74abe5cef7b5cb71deb3b5"
   dependencies:
-    b64 "3.x.x"
-    boom "5.x.x"
-    content "3.x.x"
-    hoek "4.x.x"
-    nigel "2.x.x"
+    b64 "4.x.x"
+    boom "7.x.x"
+    content "4.x.x"
+    hoek "5.x.x"
+    nigel "3.x.x"
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -1766,13 +1774,12 @@ pn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.0.0.tgz#1cf5a30b0d806cd18f88fc41a6b5d4ad615b3ba9"
 
-podium@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/podium/-/podium-1.3.0.tgz#3c490f54d16f10f5260cbe98641f1cb733a8851c"
+podium@3.x.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/podium/-/podium-3.1.2.tgz#b701429739cf6bdde6b3015ae6b48d400817ce9e"
   dependencies:
-    hoek "4.x.x"
-    items "2.x.x"
-    joi "10.x.x"
+    hoek "5.x.x"
+    joi "13.x.x"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -1966,12 +1973,12 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shot@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/shot/-/shot-3.4.2.tgz#1e5c3f6f2b26649adc42f7eb350214a5a0291d67"
+shot@4.x.x:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/shot/-/shot-4.0.4.tgz#cb0d3f61f6588ee23c3eb077f87b17a100d581a2"
   dependencies:
-    hoek "4.x.x"
-    joi "10.x.x"
+    hoek "5.x.x"
+    joi "13.x.x"
 
 sinon-as-promised@4.0.2:
   version "4.0.2"
@@ -2021,16 +2028,16 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-statehood@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/statehood/-/statehood-5.0.3.tgz#c07a75620db5379b60d2edd47f538002a8ac7dd6"
+statehood@6.x.x:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/statehood/-/statehood-6.0.5.tgz#bbcdcb3a43a6fb86f4bd04ed48a9309b6cfc1b18"
   dependencies:
-    boom "5.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    iron "4.x.x"
-    items "2.x.x"
-    joi "10.x.x"
+    boom "7.x.x"
+    bounce "1.x.x"
+    cryptiles "4.x.x"
+    hoek "5.x.x"
+    iron "5.x.x"
+    joi "13.x.x"
 
 stealthy-require@^1.1.0:
   version "1.1.1"
@@ -2085,15 +2092,15 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-subtext@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/subtext/-/subtext-5.0.0.tgz#9c3f083018bb1586b167ad8cfd87083f5ccdfe0f"
+subtext@6.x.x:
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/subtext/-/subtext-6.0.7.tgz#8e40a67901a734d598142665c90e398369b885f9"
   dependencies:
-    boom "5.x.x"
-    content "3.x.x"
-    hoek "4.x.x"
-    pez "2.x.x"
-    wreck "12.x.x"
+    boom "7.x.x"
+    content "4.x.x"
+    hoek "5.x.x"
+    pez "4.x.x"
+    wreck "14.x.x"
 
 superagent@~0.21.0:
   version "0.21.0"
@@ -2136,6 +2143,10 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
+teamwork@3.x.x:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/teamwork/-/teamwork-3.0.1.tgz#ff38c7161f41f8070b7813716eb6154036ece196"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2148,11 +2159,11 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
-topo@2.x.x, topo@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
+topo@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.0.tgz#37e48c330efeac784538e0acd3e62ca5e231fe7a"
   dependencies:
-    hoek "4.x.x"
+    hoek "5.x.x"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.3:
   version "2.3.3"
@@ -2244,11 +2255,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vise@2.x.x:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/vise/-/vise-2.0.2.tgz#6b08e8fb4cb76e3a50cd6dd0ec37338e811a0d39"
+vise@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vise/-/vise-3.0.0.tgz#76ad14ab31669c50fbb0817bc0e72fedcbb3bf4c"
   dependencies:
-    hoek "4.x.x"
+    hoek "5.x.x"
 
 webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
@@ -2276,12 +2287,12 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-wreck@12.x.x:
-  version "12.5.1"
-  resolved "https://registry.yarnpkg.com/wreck/-/wreck-12.5.1.tgz#cd2ffce167449e1f0242ed9cf80552e20fb6902a"
+wreck@14.x.x:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/wreck/-/wreck-14.0.2.tgz#89c17a9061c745ed1c3aebcb66ea181dbaab454c"
   dependencies:
-    boom "5.x.x"
-    hoek "4.x.x"
+    boom "7.x.x"
+    hoek "5.x.x"
 
 write@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
As you might have noticed, Hapi with version 17 has recently moved to using async/await. This requires breaking changes. Luckily it was quite simple in our case. All Hapi related dependencies have also been updated to the latest versions.

Fix #51 