### PR TITLE
Add bulk endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "json-path": "^0.1.3",
     "keen-js": "^4.3.0",
     "lets-get-meta": "^2.1.1",
+    "lodash.countby": "^4.6.0",
     "memory-cache": "^0.2.0",
     "newrelic": "^2.2.2",
+    "promise-limit": "^2.6.0",
     "require-dir": "^0.3.2"
   },
   "repository": {

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const resolverPlugin = require('./src/plugins/universal-resolver.js');
 const javaPlugin = require('./src/plugins/java-resolver.js');
 const pingPlugin = require('./src/plugins/ping.js');
 const homePlugin = require('./src/plugins/home.js');
+const bulkPlugin = require('./src/plugins/bulk.js');
 
 const server = new hapi.Server({
   port: process.env.PORT || 3000,
@@ -22,6 +23,7 @@ const init = async () => {
     melpaResolverPlugin,
     pingPlugin,
     homePlugin,
+    bulkPlugin,
   ]);
 
   await server.start();

--- a/src/plugins/bulk.js
+++ b/src/plugins/bulk.js
@@ -2,7 +2,7 @@ const insight = require('../utils/insight.js');
 const promiseLimit = require('promise-limit');
 const countBy = require('lodash.countby');
 
-const MAXIMUM_CONCURREN_TREQUESTS = 20;
+const MAXIMUM_CONCURRENT_REQUESTS = 20;
 
 function track(request) {
   const { payload } = request;
@@ -24,7 +24,7 @@ const register = (server) => {
 
         track(request);
 
-        const limit = promiseLimit(MAXIMUM_CONCURREN_TREQUESTS);
+        const limit = promiseLimit(MAXIMUM_CONCURRENT_REQUESTS);
 
         return Promise.all(payload.map((item) => {
           if (item.type === 'registry') {

--- a/src/plugins/bulk.js
+++ b/src/plugins/bulk.js
@@ -1,0 +1,58 @@
+const insight = require('../utils/insight.js');
+const promiseLimit = require('promise-limit');
+const countBy = require('lodash.countby');
+
+const MAXIMUM_CONCURREN_TREQUESTS = 20;
+
+function track(request) {
+  const { payload } = request;
+
+  const trackData = Object.assign({
+    totalLength: payload.length,
+  }, countBy(payload, 'type'));
+
+  insight.trackEvent('bulk', trackData, request);
+}
+
+const register = (server) => {
+  server.route([{
+    path: '/bulk',
+    method: 'POST',
+    config: {
+      handler: async (request) => {
+        const { payload } = request;
+
+        track(request);
+
+        const limit = promiseLimit(MAXIMUM_CONCURREN_TREQUESTS);
+
+        return Promise.all(payload.map((item) => {
+          if (item.type === 'registry') {
+            return limit(() => server.inject({
+              method: 'get',
+              url: `/q/${item.registry}/${item.target}`,
+            }));
+          } else if (item.type === 'ping') {
+            return limit(() => server.inject({
+              method: 'get',
+              url: `/ping?url=${item.target}`,
+            }));
+          }
+        }))
+        .then(values => values.map((item) => {
+          if (item && item.result && item.result.url) {
+            return item.result.url;
+          }
+
+          return null;
+        }));
+      },
+    },
+  }]);
+};
+
+exports.plugin = {
+  name: 'Bulk',
+  version: '1.0.0',
+  register,
+};

--- a/test/functional.js
+++ b/test/functional.js
@@ -33,4 +33,27 @@ parallel('functional', () => {
   testUrl('/q/go/k8s.io/kubernetes/pkg/api', 'https://github.com/kubernetes/kubernetes/tree/master/pkg/api');
   testUrl('/q/melpa/zzz-to-char', 'https://github.com/mrkkrp/zzz-to-char');
   testUrl('/q/java/org.apache.log4j.Appender', 'https://www.slf4j.org/api/org/apache/log4j/Appender.html');
+  testUrl('/ping?url=https://nodejs.org/api/path.html', 'https://nodejs.org/api/path.html');
+
+  it('resolves /bulk request', async () => {
+    const response = await got.post(`${server.info.uri}/bulk`, {
+      body: JSON.stringify([
+        { type: 'registry', registry: 'composer', target: 'phpunit/phpunit' },
+        { type: 'registry', registry: 'npm', target: 'ihopethisdoesnotexist' },
+        { type: 'ping', target: 'https://nodejs.org/api/path.html' },
+        { type: 'registry', registry: 'npm', target: 'request' },
+        { type: 'ping', target: 'http://not.found.org' },
+        { type: 'registry', registry: 'bower', target: 'jquery' },
+      ]),
+    });
+
+
+    const body = JSON.parse(response.body);
+    assert.equal(body[0], 'https://github.com/sebastianbergmann/phpunit');
+    assert.equal(body[1], null);
+    assert.equal(body[2], 'https://nodejs.org/api/path.html');
+    assert.equal(body[3], 'https://github.com/request/request');
+    assert.equal(body[4], null);
+    assert.equal(body[5], 'https://github.com/jquery/jquery-dist');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,6 +1475,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.countby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.countby/-/lodash.countby-4.6.0.tgz#5351f24de16724a0059b561f920b0d80af78a33c"
+
 lodash.create@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
@@ -1834,6 +1838,10 @@ process-nextick-args@~2.0.0:
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+
+promise-limit@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/promise-limit/-/promise-limit-2.6.0.tgz#cb6959fcfdd0ee6ec694ec58b2b3b856ca52ffed"
 
 pseudomap@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Towards our mission to use real links (see https://github.com/OctoLinker/OctoLinker/issues/277), this PR adds a new bulk endpoint to our service. This is needed to reduce response times and server load when prefetching links for the OctoLinker browser extension. 

The order of the response is equal to the order in request body. If a query fails or can't be resolved the api will return `null`. 


#### Request body

```json
[
    {
        "type": "registry",
        "registry": "npm",
        "target": "request"
    },
    {
        "type": "ping",
        "target": "https://nodejs.org/api/path.html"
    },
    {
        "type": "registry",
        "registry": "npm",
        "target": "package_which_does_not_exist"
    }
]
```

### Response

```json
[
	"https://github.com/request/request",
	"https://nodejs.org/api/path.html",
	null
]
```

