### PR TITLE
Use keen-tracking to make jest working

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "is-url": "^1.2.2",
     "joi": "^13.0.2",
     "json-path": "^0.1.3",
-    "keen-js": "^4.3.0",
+    "keen-tracking": "^1.4.0",
     "lets-get-meta": "^2.1.1",
     "lodash.countby": "^4.6.0",
     "memory-cache": "^0.2.0",

--- a/src/utils/insight.js
+++ b/src/utils/insight.js
@@ -1,4 +1,4 @@
-const Keen = require('keen-js');
+const Keen = require('keen-tracking');
 
 let instance;
 
@@ -21,7 +21,7 @@ function trackEvent(eventKey, eventData, request) {
   }
 
   if (instance) {
-    instance.addEvent(eventKey, data);
+    instance.recordEvent(eventKey, data);
   } else {
     console.log(eventKey, data);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,10 +170,6 @@ bluebird@^2.9.34:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
 
-bluebird@^3.2.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-
 boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -227,12 +223,6 @@ browser-stdout@1.3.0:
 builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-
-c3@^0.4.18:
-  version "0.4.21"
-  resolved "https://registry.yarnpkg.com/c3/-/c3-0.4.21.tgz#61a2dc5a31c6a64e011d15b136c160c44fbb9631"
-  dependencies:
-    d3 "~3.5.0"
 
 call@5.x.x:
   version "5.0.1"
@@ -422,10 +412,6 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
     cssom "0.3.x"
-
-d3@^3.5.17, d3@~3.5.0:
-  version "3.5.17"
-  resolved "https://registry.yarnpkg.com/d3/-/d3-3.5.17.tgz#bc46748004378b21a360c9fc7cf5231790762fb8"
 
 d@1:
   version "1.0.0"
@@ -1381,41 +1367,13 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-keen-analysis@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/keen-analysis/-/keen-analysis-1.3.0.tgz#8d9598d41dfda20a6ed369f37210d1f9e0f6703f"
-  dependencies:
-    bluebird "^3.2.1"
-    keen-core "^0.2.0"
-
 keen-core@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/keen-core/-/keen-core-0.1.3.tgz#b78cccad3cd62ef2e35196984d9b370bec6b1ce2"
   dependencies:
     component-emitter "^1.2.0"
 
-keen-core@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/keen-core/-/keen-core-0.2.0.tgz#5910f9309b6ef2901cd3493bab5a1837b00a9b5b"
-  dependencies:
-    component-emitter "^1.2.0"
-
-keen-dataviz@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/keen-dataviz/-/keen-dataviz-1.2.1.tgz#6f7595a2051652e1bece2ce2296e47ffa5d79dd9"
-  dependencies:
-    c3 "^0.4.18"
-    d3 "^3.5.17"
-
-keen-js@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/keen-js/-/keen-js-4.3.0.tgz#32d6bd79d0d8b881f6678bdf2d8e93ef112dab37"
-  dependencies:
-    keen-analysis "1.3.0"
-    keen-dataviz "1.2.1"
-    keen-tracking "1.4.0"
-
-keen-tracking@1.4.0:
+keen-tracking@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/keen-tracking/-/keen-tracking-1.4.0.tgz#7951cc2da2ea68c4aa8c04a4bb3c411d0c03cf99"
   dependencies:


### PR DESCRIPTION
The problem is that keen-dataviz.js uses c3.js. We don't use chart so in our case the solution is to install keen-tracking and remove keen-js.