### PR TITLE
Store service start in keen.io

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const javaPlugin = require('./src/plugins/java-resolver.js');
 const pingPlugin = require('./src/plugins/ping.js');
 const homePlugin = require('./src/plugins/home.js');
 const bulkPlugin = require('./src/plugins/bulk.js');
+const insight = require('./src/utils/insight.js');
 
 const server = new hapi.Server({
   port: process.env.PORT || 3000,
@@ -28,10 +29,15 @@ const init = async () => {
 
   await server.start();
 
+  insight.trackEvent('service_start');
+
   console.log(`Server running at: ${server.info.uri}`);
 };
 
 init().catch((err) => {
+  insight.trackEvent('service_error', {
+    error: err.toString(),
+  });
   console.log(err);
   process.exit(1);
 });


### PR DESCRIPTION
Although this information exists in the server logs I think using keen.io has some advantages. First of all, logs aren't a good place to store data for a long term. Also Heroku caps the logs so we can only see a small range. With the recently added bulk endpoint we will get much more traffic on this service soon. Therefore I would like to be able to see restarts over a longer time period.