### PR TITLE
Fix / add caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "mem": "^3.0.0",
     "newrelic": "^2.2.2",
     "promise-limit": "^2.6.0",
-    "require-directory": "^2.1.1"
+    "require-directory": "^2.1.1",
+    "timeunits": "^1.1.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "keen-tracking": "^1.4.0",
     "lets-get-meta": "^2.1.1",
     "lodash.countby": "^4.6.0",
+    "mem": "^3.0.0",
     "newrelic": "^2.2.2",
     "promise-limit": "^2.6.0",
     "require-directory": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "keen-tracking": "^1.4.0",
     "lets-get-meta": "^2.1.1",
     "lodash.countby": "^4.6.0",
-    "memory-cache": "^0.2.0",
     "newrelic": "^2.2.2",
     "promise-limit": "^2.6.0",
     "require-directory": "^2.1.1"

--- a/src/plugins/go-resolver.js
+++ b/src/plugins/go-resolver.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 const findReachableUrls = require('find-reachable-urls');
 const readMeta = require('lets-get-meta');
+const pMemoize = require('mem');
 const got = require('got');
 const insight = require('../utils/insight');
 
@@ -21,7 +22,7 @@ const getGoMeta = async (url) => {
   };
 };
 
-const resolveUrl = async (url) => {
+const resolveUrl = pMemoize(async (url) => {
   let goMetaConfig;
 
   try {
@@ -42,7 +43,7 @@ const resolveUrl = async (url) => {
   }
 
   return reachableUrl;
-};
+}, { maxAge: 86400000 });
 
 const register = (server) => {
   server.route([{

--- a/src/plugins/go-resolver.js
+++ b/src/plugins/go-resolver.js
@@ -3,6 +3,7 @@ const findReachableUrls = require('find-reachable-urls');
 const readMeta = require('lets-get-meta');
 const pMemoize = require('mem');
 const got = require('got');
+const timeunits = require('timeunits');
 const insight = require('../utils/insight');
 
 const getGoMeta = async (url) => {
@@ -43,7 +44,7 @@ const resolveUrl = pMemoize(async (url) => {
   }
 
   return reachableUrl;
-}, { maxAge: 86400000 });
+}, { maxAge: timeunits.year });
 
 const register = (server) => {
   server.route([{

--- a/src/plugins/melpa-resolver.js
+++ b/src/plugins/melpa-resolver.js
@@ -1,12 +1,13 @@
 const Joi = require('joi');
 const findReachableUrls = require('find-reachable-urls');
 const got = require('got');
+const pMemoize = require('mem');
 const insight = require('../utils/insight');
 
 let lastModified;
 let archive;
 
-const resolveUrl = async (pkg) => {
+const resolveUrl = pMemoize(async (pkg) => {
   const response = await got('https://melpa.org/archive.json', {
     json: true,
     headers: lastModified ? {
@@ -29,7 +30,7 @@ const resolveUrl = async (pkg) => {
   }
 
   return reachableUrl;
-};
+}, { maxAge: 86400000 });
 
 const register = (server) => {
   server.route([{

--- a/src/plugins/melpa-resolver.js
+++ b/src/plugins/melpa-resolver.js
@@ -2,6 +2,7 @@ const Joi = require('joi');
 const findReachableUrls = require('find-reachable-urls');
 const got = require('got');
 const pMemoize = require('mem');
+const timeunits = require('timeunits');
 const insight = require('../utils/insight');
 
 let lastModified;
@@ -30,7 +31,7 @@ const resolveUrl = pMemoize(async (pkg) => {
   }
 
   return reachableUrl;
-}, { maxAge: 86400000 });
+}, { maxAge: timeunits.year });
 
 const register = (server) => {
   server.route([{

--- a/src/plugins/ping.js
+++ b/src/plugins/ping.js
@@ -17,7 +17,7 @@ const register = (server) => {
         const url = request.query.url;
 
         try {
-          await got.head(url);
+          await got.get(url);
           insight.trackEvent('ping_resolved', {
             url,
           }, request);

--- a/src/plugins/ping.js
+++ b/src/plugins/ping.js
@@ -1,7 +1,6 @@
-const got = require('got');
 const Boom = require('boom');
-
 const Joi = require('joi');
+const got = require('../utils/memRequest.js');
 const insight = require('../utils/insight.js');
 
 const register = (server) => {
@@ -18,7 +17,7 @@ const register = (server) => {
         const url = request.query.url;
 
         try {
-          await got.get(url);
+          await got.head(url);
           insight.trackEvent('ping_resolved', {
             url,
           }, request);

--- a/src/plugins/universal-resolver.js
+++ b/src/plugins/universal-resolver.js
@@ -1,8 +1,9 @@
 const Joi = require('joi');
 const pMemoize = require('mem');
+const timeunits = require('timeunits');
 const insight = require('../utils/insight.js');
 const registryConfig = require('../../config.json');
-const doRequest = pMemoize(require('../utils/do-request.js'), { maxAge: 86400000 });
+const doRequest = pMemoize(require('../utils/do-request.js'), { maxAge: timeunits.year });
 
 const register = (server) => {
   server.route([{

--- a/src/plugins/universal-resolver.js
+++ b/src/plugins/universal-resolver.js
@@ -1,7 +1,8 @@
 const Joi = require('joi');
+const pMemoize = require('mem');
 const insight = require('../utils/insight.js');
 const registryConfig = require('../../config.json');
-const doRequest = require('../utils/do-request.js');
+const doRequest = pMemoize(require('../utils/do-request.js'), { maxAge: 86400000 });
 
 const register = (server) => {
   server.route([{

--- a/src/utils/memRequest.js
+++ b/src/utils/memRequest.js
@@ -1,4 +1,5 @@
 const pMemoize = require('mem');
 const got = require('got');
+const timeunits = require('timeunits');
 
-module.exports = pMemoize(got, { maxAge: 86400000 });
+module.exports = pMemoize(got, { maxAge: timeunits.year });

--- a/src/utils/memRequest.js
+++ b/src/utils/memRequest.js
@@ -1,0 +1,4 @@
+const pMemoize = require('mem');
+const got = require('got');
+
+module.exports = pMemoize(got, { maxAge: 86400000 });

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -16,7 +16,7 @@ describe('ping', () => {
 
   afterAll(() => server.stop());
 
-  it('performs an HTTP HEAD request', async () => {
+  it('performs an HTTP GET request', async () => {
     got.get.mockResolvedValue();
 
     const options = {
@@ -24,14 +24,14 @@ describe('ping', () => {
     };
 
     await server.inject(options);
-    expect(got.head.mock.calls).toHaveLength(1);
-    expect(got.head.mock.calls[0][0]).toBe('http://awesomefooland.com');
+    expect(got.get.mock.calls).toHaveLength(1);
+    expect(got.get.mock.calls[0][0]).toBe('http://awesomefooland.com');
   });
 
   it('returns 404 response if package can not be found', async () => {
     const err = new Error('Some error');
     err.code = 404;
-    got.head.mockRejectedValue(err);
+    got.get.mockRejectedValue(err);
 
     const options = {
       method: 'GET',
@@ -43,7 +43,7 @@ describe('ping', () => {
   });
 
   it('returns project url', async () => {
-    got.head.mockResolvedValue();
+    got.get.mockResolvedValue();
 
     const options = {
       method: 'GET',

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -24,14 +24,14 @@ describe('ping', () => {
     };
 
     await server.inject(options);
-    expect(got.get.mock.calls).toHaveLength(1);
-    expect(got.get.mock.calls[0][0]).toBe('http://awesomefooland.com');
+    expect(got.head.mock.calls).toHaveLength(1);
+    expect(got.head.mock.calls[0][0]).toBe('http://awesomefooland.com');
   });
 
   it('returns 404 response if package can not be found', async () => {
     const err = new Error('Some error');
     err.code = 404;
-    got.get.mockRejectedValue(err);
+    got.head.mockRejectedValue(err);
 
     const options = {
       method: 'GET',
@@ -43,7 +43,7 @@ describe('ping', () => {
   });
 
   it('returns project url', async () => {
-    got.get.mockResolvedValue();
+    got.head.mockResolvedValue();
 
     const options = {
       method: 'GET',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,6 +4046,10 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
+timeunits@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/timeunits/-/timeunits-1.1.0.tgz#aab8995f13fc20c2c0feb6da4ba5966333570eda"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,10 +2842,6 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-memory-cache@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/memory-cache/-/memory-cache-0.2.0.tgz#7890b01d52c00c8ebc9d533e1f8eb17e3034871a"
-
 merge-stream@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,6 +2842,13 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+mem@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-3.0.0.tgz#84e58ad4dfbdf5d105b26b6548a398b2b3aa8a21"
+  dependencies:
+    mimic-fn "^1.0.0"
+    p-is-promise "^1.1.0"
+
 merge-stream@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
@@ -3187,6 +3194,10 @@ p-cancelable@^0.3.0:
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
 
 p-limit@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
Three years ago, I implemented caching to speed up the service 8607b5f31c5db81499aaf7bba9ee6732fc53d0dd. Last week I noticed that his isn't in place anymore. Looks like I removed it 198c23fc33cbaedf047eae36df87607c6862037d.

With the upcoming refactoring of the browser extension the load on the service will increase dramatically. Therefore we need a solid caching in place. I added [mem](https://github.com/sindresorhus/mem) to cache the responses in memory. 

The implementation was straight forward. There is only thing I didn't like. In `ping.js` I had to wrap the `got` module in another file to make the stub working. @josephfrazier if you have any better way to solve this, please let me know.