### PR TITLE
Perform HEAD request for ping requests

### DIFF
--- a/src/plugins/ping.js
+++ b/src/plugins/ping.js
@@ -18,7 +18,7 @@ const register = (server) => {
         const url = request.query.url;
 
         try {
-          await got.get(url);
+          await got.head(url);
           insight.trackEvent('ping_resolved', {
             url,
           }, request);

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -17,21 +17,21 @@ describe('ping', () => {
   afterAll(() => server.stop());
 
   it('performs an HTTP HEAD request', async () => {
-    got.get.mockResolvedValue();
+    got.head.mockResolvedValue();
 
     const options = {
       url: '/ping?url=http://awesomefooland.com',
     };
 
     await server.inject(options);
-    expect(got.get.mock.calls).toHaveLength(1);
-    expect(got.get.mock.calls[0][0]).toBe('http://awesomefooland.com');
+    expect(got.head.mock.calls).toHaveLength(1);
+    expect(got.head.mock.calls[0][0]).toBe('http://awesomefooland.com');
   });
 
   it('returns 404 response if package can not be found', async () => {
     const err = new Error('Some error');
     err.code = 404;
-    got.get.mockRejectedValue(err);
+    got.head.mockRejectedValue(err);
 
     const options = {
       method: 'GET',
@@ -43,7 +43,7 @@ describe('ping', () => {
   });
 
   it('returns project url', async () => {
-    got.get.mockResolvedValue();
+    got.head.mockResolvedValue();
 
     const options = {
       method: 'GET',


### PR DESCRIPTION
For some reason a HTTP GET request sneaked in when making a ping request. A HEAD request is the appropriate way to reduce the request size. 