### PR TITLE
Use custom header to avoid clash with the DNT standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Run server:
 
 Our [Privacy Policy](https://github.com/OctoLinker/OctoLinker/blob/master/privacy-policy.md) describes our practices related to the use, storage and disclosure of information we collect when you're using our service.
 
+If you do not want your requests to be logged, you can opt-out of logging by sending `'Do-Not-Track': '1'` or `'DNT': '1'` in the request headers.
+
 ## License
 
 Copyright (c) 2015 Stefan Buck. Licensed under the MIT license.

--- a/src/utils/insight.js
+++ b/src/utils/insight.js
@@ -15,10 +15,13 @@ function init() {
 
 function doNotTrack(request = {}) {
   if (!request.headers) {
-    return true;
+    return false;
   }
 
-  return parseInt(request.headers.dnt, 10) === 1;
+  return [
+    request.headers.dnt,
+    request.headers['do-not-track'],
+  ].includes('1');
 }
 
 function trackEvent(eventKey, eventData, request) {


### PR DESCRIPTION
Yesterday, a new version of OctoLinker was released with the option to opt-out of logging. Today, I noticed that this isn't working as expected. Setting `DNT: 1` cause the browser to throw the following error.

```
Refused to set unsafe header DNT
```

I'm not 100% sure why I can't set this header, but I worked around by introducing a custom header called `do-not-track`.  

