### PR TITLE
Strip multiple spaces from go-source meta tag

### DIFF
--- a/src/plugins/go-resolver.js
+++ b/src/plugins/go-resolver.js
@@ -14,7 +14,7 @@ const getGoMeta = async (url) => {
     throw new Error('go-source meta is missing');
   }
 
-  const values = meta['go-source'].replace(/\s+/, ' ').split(' ');
+  const values = meta['go-source'].replace(/\s+/g, ' ').split(' ');
 
   return {
     projectRoot: values[0],


### PR DESCRIPTION
When requesting https://githublinker.herokuapp.com/q/go/k8s.io/kubernetes/pkg/api it responds with `{"url":"https://github.com/kubernetes/kubernetes\n"}` which should be`{"url":"https://github.com/kubernetes/kubernetes/tree/master/pkg/api"}` 

A `curl` of `https://k8s.io/kubernetes/pkg/api\?go-get\=1` shows a few white spaces and new lines within the `<meta name="go-source" content="....`

```html
         <html><head>
                  <meta name="go-import"
                        content="k8s.io/kubernetes
                                 git https://github.com/kubernetes/kubernetes">
                  <meta name="go-source"
                        content="k8s.io/kubernetes
                                 https://github.com/kubernetes/kubernetes
                                 https://github.com/kubernetes/kubernetes/tree/master{/dir}
                                 https://github.com/kubernetes/kubernetes/blob/master{/dir}/{file}#L{line}">
            </head></html>
```

After taking all whitespace (spaces, tabs and new lines) into account it works.

