### PR TITLE
New caching strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "keen-tracking": "^1.4.0",
     "lets-get-meta": "^2.1.1",
     "lodash.countby": "^4.6.0",
-    "mem": "^3.0.0",
+    "ms": "^2.1.1",
     "newrelic": "^4.0.0",
     "promise-limit": "^2.6.0",
-    "require-directory": "^2.1.1",
-    "timeunits": "^1.1.0"
+    "receptacle": "^1.3.2",
+    "require-directory": "^2.1.1"
   },
   "repository": {
     "type": "git",

--- a/src/plugins/ping.js
+++ b/src/plugins/ping.js
@@ -1,6 +1,7 @@
 const Boom = require('boom');
 const Joi = require('joi');
-const got = require('../utils/memRequest.js');
+const got = require('got');
+const cache = require('../utils/cache');
 const insight = require('../utils/insight.js');
 
 const register = (server) => {
@@ -16,11 +17,19 @@ const register = (server) => {
       handler: async (request) => {
         const url = request.query.url;
 
+        const cacheKey = `ping_${url}`;
+
+        if (cache.has(cacheKey)) {
+          return cache.get(cacheKey);
+        }
+
         try {
           await got.head(url);
           insight.trackEvent('ping_resolved', {
             url,
           }, request);
+
+          cache.set(cacheKey, { url });
 
           return {
             url,

--- a/src/plugins/universal-resolver.js
+++ b/src/plugins/universal-resolver.js
@@ -1,9 +1,7 @@
 const Joi = require('joi');
-const pMemoize = require('mem');
-const timeunits = require('timeunits');
 const insight = require('../utils/insight.js');
 const registryConfig = require('../../config.json');
-const doRequest = pMemoize(require('../utils/do-request.js'), { maxAge: timeunits.year });
+const doRequest = require('../utils/do-request.js');
 
 const register = (server) => {
   server.route([{

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,0 +1,12 @@
+const ms = require('ms');
+const Receptacle = require('receptacle');
+
+const cache = new Receptacle();
+
+module.exports = {
+  set: (key, value) => {
+    cache.set(key, value, { ttl: ms('30m'), refresh: true });
+  },
+  get: key => cache.get(key),
+  has: key => cache.has(key),
+};

--- a/src/utils/memRequest.js
+++ b/src/utils/memRequest.js
@@ -1,5 +1,0 @@
-const pMemoize = require('mem');
-const got = require('got');
-const timeunits = require('timeunits');
-
-module.exports = pMemoize(got, { maxAge: timeunits.year });

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -3,6 +3,7 @@ const hapi = require('hapi');
 const plugin = require('../src/plugins/ping.js');
 
 jest.mock('got');
+jest.mock('../src/utils/cache');
 
 describe('ping', () => {
   let server;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,14 +3225,6 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-mem@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-3.0.1.tgz#152410d0d7e835e4a4363e626238d9e5be3d6f5a"
-  integrity sha512-QKs47bslvOE0NbXOqG6lMxn6Bk0Iuw0vfrIeLykmQle2LkCw1p48dZDdzE+D88b/xqRJcZGcMNeDvSVma+NuIQ==
-  dependencies:
-    mimic-fn "^1.0.0"
-    p-is-promise "^1.1.0"
-
 merge-stream@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
@@ -3674,11 +3666,6 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
-p-is-promise@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
-  integrity sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
-
 p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
@@ -3999,6 +3986,13 @@ realpath-native@^1.0.0:
   integrity sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==
   dependencies:
     util.promisify "^1.0.0"
+
+receptacle@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/receptacle/-/receptacle-1.3.2.tgz#a7994c7efafc7a01d0e2041839dab6c4951360d2"
+  integrity sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==
+  dependencies:
+    ms "^2.1.1"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -4639,11 +4633,6 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
-
-timeunits@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/timeunits/-/timeunits-1.1.0.tgz#aab8995f13fc20c2c0feb6da4ba5966333570eda"
-  integrity sha512-VIn827yfv6P0qIFcyjESA4nLO4CYAAcnd3XLNxHQ44XnVigGsA2Wbzg6Bg8N7IQMiA0g4tQa+/IPSxdyHiXJEA==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
The mem package was a quite simple solution to add caching in the first place. Now with more traffic on the service a caching strategy that supports ttl is needed to maintain a healthy memory consumption. [receptacle](https://www.npmjs.com/package/receptacle) looks pretty good for this job. Btw this PR is already running in production since yesterday so it's already battle tested.