### PR TITLE
npm: Support lerna-style repositories

### DIFF
--- a/src/utils/do-request.js
+++ b/src/utils/do-request.js
@@ -45,6 +45,7 @@ module.exports = async function doRequest(packageName, type) {
 
     if (type === 'npm') {
       try {
+        urls.unshift(...urls.map(url => `${url}/tree/master/packages/${packageName}`));
         urls.push(...json.maintainers.map(({ name }) => `${name}/${packageName}`));
       } catch (err) {
         console.log(err);

--- a/test/functional.spec.js
+++ b/test/functional.spec.js
@@ -26,6 +26,7 @@ describe('functional', () => {
   testUrl('/q/npm/audio-context-polyfill', 'https://www.npmjs.com/package/audio-context-polyfill');
   testUrl('/q/npm/github-url-from-username-repo', 'https://github.com/robertkowalski/github-url-from-username-repo');
   testUrl('/q/npm/find-project-root', 'https://github.com/kirstein/find-project-root');
+  testUrl('/q/npm/jest-mock', 'https://github.com/facebook/jest/tree/master/packages/jest-mock');
   testUrl('/q/pypi/simplejson', 'https://github.com/simplejson/simplejson');
   testUrl('/q/crates/libc', 'https://github.com/rust-lang/libc');
   testUrl('/q/go/k8s.io/kubernetes/pkg/api', 'https://github.com/kubernetes/kubernetes/tree/master/pkg/api');


### PR DESCRIPTION
Fixes https://github.com/OctoLinker/OctoLinker/issues/535, which is
paraphrased below:

I clicked a link to the `jest-mock` package and expected to be taken to
https://github.com/facebook/jest/tree/master/packages/jest-mock.
However, I was taken to https://github.com/facebook/jest instead.

[Lerna] is growing in popularity, so this checks to see if (for example)
the `tree/master/packages/jest-mock` URL works, and go to it instead
of the repo root if possible.

[Lerna]: https://lernajs.io/