### PR TITLE
When resolving with a cache result respond with json format

### DIFF
--- a/src/plugins/universal-resolver.js
+++ b/src/plugins/universal-resolver.js
@@ -29,7 +29,7 @@ const register = (server) => {
           eventData.url = npmStaticCache[pkg];
           insight.trackEvent('resolved', eventData, request);
 
-          return eventData.url;
+          return { url: eventData.url };
         }
 
         try {

--- a/test/functional.spec.js
+++ b/test/functional.spec.js
@@ -21,6 +21,7 @@ describe('functional', () => {
   testUrl('/q/bower/jquery', 'https://github.com/jquery/jquery-dist');
   testUrl('/q/composer/phpunit/phpunit', 'https://github.com/sebastianbergmann/phpunit');
   testUrl('/q/rubygems/nokogiri', 'https://github.com/sparklemotion/nokogiri');
+  testUrl('/q/npm/eslint', 'https://github.com/eslint/eslint');
   testUrl('/q/npm/request', 'https://github.com/request/request');
   testUrl('/q/npm/babel-helper-regex', 'https://github.com/babel/babel/tree/master/packages/babel-helper-regex');
   testUrl('/q/npm/audio-context-polyfill', 'https://www.npmjs.com/package/audio-context-polyfill');


### PR DESCRIPTION
My previous PR #77 introduced an issue when resolving packages from the static cache file. The response format needs to be a JSON like`{ url: 'http://' }`, but instead just an URL string was returned. We didn't catch this earlier, because non of our functional tests was querying a package from the cache file. 